### PR TITLE
Allow encode nil values in a method call

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -18,7 +18,7 @@ type encodeFunc func(reflect.Value) ([]byte, error)
 
 func Marshal(v interface{}) ([]byte, error) {
 	if v == nil {
-		return []byte{}, nil
+		return []byte("<value/>"), nil
 	}
 
 	val := reflect.ValueOf(v)


### PR DESCRIPTION
Address partially https://github.com/uyuni-project/hub-xmlrpc-api/issues/66